### PR TITLE
fix: resolve to absolute path

### DIFF
--- a/packages/snapshot/src/snapshot.ts
+++ b/packages/snapshot/src/snapshot.ts
@@ -2,7 +2,7 @@ import { createElement } from '@timecat/virtual-dom'
 import { InfoData, DOMSnapshotData, VNode } from '@timecat/share'
 
 function getInitInfo(): InfoData {
-    const { name, publicId, systemId } = window.document.doctype!
+    const { name, publicId, systemId } = window.document.doctype || {}
     const doctype = () => ({ name, publicId, systemId } as DocumentType)
     const origin = () => window.location.origin
     const pathname = () => window.location.pathname

--- a/packages/utils/src/tools/dom.ts
+++ b/packages/utils/src/tools/dom.ts
@@ -55,6 +55,10 @@ function stitchingLink(pre: string, next: string) {
     return pre + '/' + next
 }
 
+export function resolveToAbsolutePath(url: string, base: string) {
+    return new URL(url, base).href
+}
+
 export function completionCssHref(str: string) {
     return str.replace(/(url\()['"]?((\/{1,2})[^'"]*?)['"]?(?=\))/g, (a, b, c) => {
         let url: string = ''
@@ -70,32 +74,12 @@ export function completionCssHref(str: string) {
     })
 }
 
-export function completionAttrHref(str: string) {
+export function completionAttrHref(str: string = '') {
     if (str.startsWith('data')) {
         return str
     }
 
-    const reg = /^(\/{1,2}.*)/g
-    str = str.replace(reg, str => {
-        if (startsWithDoubleSlash(str)) {
-            return stitchingLink(protocol(), str.substring(2))
-        }
-
-        if (startsWithSlash(str)) {
-            return stitchingLink(origin(), str)
-        }
-        return str
-    })
-
-    if (!/^http/.test(str)) {
-        if (str.startsWith('./')) {
-            return stitchingLink(href(), str.substring(1))
-        } else {
-            return stitchingLink(origin(), str)
-        }
-    }
-
-    return str
+    return resolveToAbsolutePath(str, href())
 }
 
 export function isHideComment(node: Node | null) {

--- a/packages/virtual-dom/src/serialize.ts
+++ b/packages/virtual-dom/src/serialize.ts
@@ -22,7 +22,7 @@ const getVNodeByEl = (el: Element, isSVG?: boolean): VNode | VSNode => {
 
 const getAttr = (el: HTMLElement & { checked: boolean }) => {
     const resAttr: { [key: string]: string } = {}
-    const { attributes, tagName } = el
+    const { attributes } = el
     if (attributes && attributes.length) {
         return Object.values(attributes).reduce((ret: { [key: string]: string }, attr) => {
             const [name, value] = extraAttr(attr)


### PR DESCRIPTION
1. remove unused variables: `tagName`
2. `window.document.doctype` may be null
3. support resolve relative path 2 absolute path, fixed the [issue](https://github.com/oct16/TimeCat/issues/16)

test:
![UtJ8Jg.png](https://s1.ax1x.com/2020/07/14/UtJ8Jg.png)