### PR TITLE
Feat/add rootContext to recorder

### DIFF
--- a/packages/player/src/components/panel.ts
+++ b/packages/player/src/components/panel.ts
@@ -13,7 +13,7 @@ import { PointerComponent } from './pointer'
 import { ProgressComponent } from './progress'
 import { ContainerComponent } from './container'
 import { BroadcasterComponent } from './broadcaster'
-import { ReplayInternalOptions } from '@timecat/share/src'
+import { ReplayInternalOptions } from '@timecat/share'
 import { Component, IComponent, html } from '../utils'
 import { ToolboxComponent } from './toolbox'
 

--- a/packages/player/src/renders/dom.ts
+++ b/packages/player/src/renders/dom.ts
@@ -8,7 +8,7 @@ import {
     VSNode
 } from '@timecat/share'
 import { isElementNode, isExistingNode, isVNode, nodeStore } from '@timecat/utils'
-import { convertVNode, createSpecialNode, setAttribute } from '@timecat/virtual-dom/src'
+import { convertVNode, createSpecialNode, setAttribute } from '@timecat/virtual-dom'
 
 function insertOrMoveNode(data: UpdateNodeData, orderSet: Set<number>) {
     const { parentId, nextId, node } = data

--- a/packages/player/src/renders/mouse.ts
+++ b/packages/player/src/renders/mouse.ts
@@ -1,5 +1,5 @@
 import { MouseEventType, MouseRecordData } from '@timecat/share'
-import { nodeStore } from '@timecat/utils/src'
+import { nodeStore } from '@timecat/utils'
 import { PlayerComponent } from '../components/player'
 
 export function renderMouse(this: PlayerComponent, data: MouseRecordData) {

--- a/packages/player/src/renders/snapshot.ts
+++ b/packages/player/src/renders/snapshot.ts
@@ -1,6 +1,6 @@
 import { SnapshotRecord } from '@timecat/share'
 import { nodeStore } from '@timecat/utils'
-import { setAttribute } from '@timecat/virtual-dom/src'
+import { setAttribute } from '@timecat/virtual-dom'
 import { createIframeDOM, injectIframeContent } from '../utils'
 
 export async function renderSnapshot(data: SnapshotRecord['data']) {

--- a/packages/player/src/utils/pure-redux/index.ts
+++ b/packages/player/src/utils/pure-redux/index.ts
@@ -9,7 +9,7 @@
 
 import { Store } from '../redux'
 import { State } from '../redux/types'
-import { ValueOf } from '@timecat/share/src'
+import { ValueOf } from '@timecat/share'
 
 export type Props = Partial<ValueOf<State>>
 

--- a/packages/recorder/src/recorder.ts
+++ b/packages/recorder/src/recorder.ts
@@ -43,7 +43,7 @@ interface RecordOptionsBase {
     visibleChange?: boolean
     visibleChangeKeepTime?: number
     disableWatchers?: Array<keyof typeof watchers>
-    keepAlive?: number
+    keepAlive?: number | false
 }
 
 interface RecordInternalOptions extends Required<RecordOptions> {
@@ -110,7 +110,7 @@ export class RecorderModule extends Pluginable {
         visibleChangeKeepTime: 5000,
         rewriteResource: [],
         disableWatchers: [],
-        keepAlive: 0
+        keepAlive: false
     } as RecordOptions
     private defaultMiddlewares: RecorderMiddleware[] = []
     private destroyStore: Set<Function> = new Set()

--- a/packages/recorder/src/recorder.ts
+++ b/packages/recorder/src/recorder.ts
@@ -34,7 +34,8 @@ export { RecordData } from '@timecat/share'
 export type RecorderMiddleware = (data: RecordData, n: () => Promise<void>) => Promise<void>
 
 interface RecordOptionsBase {
-    context?: Window
+    context?: Window,
+    rootContext?: Window,
     audio?: boolean
     write?: boolean
     keep?: boolean
@@ -130,6 +131,7 @@ export class RecorderModule extends Pluginable {
     constructor(options?: RecordOptions) {
         super(options)
         const opts = { ...RecorderModule.defaultRecordOpts, ...options } as RecordInternalOptions
+        opts.rootContext = opts.rootContext || opts.context
         this.options = opts
         this.watchers = this.getWatchers() as typeof Watcher[]
         this.init()
@@ -234,7 +236,7 @@ export class RecorderModule extends Pluginable {
     private async startRecord(options: RecordInternalOptions) {
         let activeWatchers = [...this.watchers, ...this.pluginWatchers]
 
-        if (options.context === window) {
+        if (options.context === this.options.rootContext) {
             if (!options.keep) {
                 this.db.clear()
             }
@@ -289,7 +291,7 @@ export class RecorderModule extends Pluginable {
 
         options.context.G_RECORD_RELATED_ID = relatedId
 
-        if (options.context === window) {
+        if (options.context === this.options.rootContext) {
             emit({
                 type: RecordType.HEAD,
                 data: headData,
@@ -382,7 +384,11 @@ export class RecorderModule extends Pluginable {
     }
 
     private createIFrameRecorder(frameWindow: Window) {
-        const frameRecorder = new RecorderModule({ context: frameWindow, keep: true })
+        const frameRecorder = new RecorderModule({ 
+            context: frameWindow, 
+            keep: true,
+            rootContext: this.options.rootContext 
+        })
         const frameElement = frameWindow.frameElement as Element & { frameRecorder: RecorderModule }
         frameElement.frameRecorder = frameRecorder
         this.destroyStore.add(() => frameRecorder.destroy())

--- a/packages/utils/__tests__/tools.spec.ts
+++ b/packages/utils/__tests__/tools.spec.ts
@@ -46,8 +46,9 @@ describe('Utils Tools Testing', () => {
     })
 
     test('Get Date Time', () => {
-        expect(getDateTime(1615218900000)).toBe('23:55:00')
-        expect(getDateTime(1615219200000)).toBe('00:00:00')
+        expect(getDateTime(1615218900000)).toBe('15:55:00')
+        expect(getDateTime(1615247700000)).toBe('23:55:00')
+        expect(getDateTime(1615248000000)).toBe('00:00:00')
     })
 
     test('To Time Stamp', () => {


### PR DESCRIPTION
Adding the `options.rootContext` to the `RecorderModule` so that I can use `mode: "live"` when context is an iframe contentWindow.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included
