### PR TITLE
fix: dispatchEvent immediately after head && snapshot

### DIFF
--- a/packages/player/src/main.ts
+++ b/packages/player/src/main.ts
@@ -203,15 +203,16 @@ export class PlayerModule {
                 if (isResolved) {
                     this.dispatchEvent('record-data', data as RecordData)
                 } else {
+                    if (data.type === RecordType.HEAD) {
+                        head = data
+                    } else if (data.type === RecordType.SNAPSHOT) {
+                        snapshot = data
+                    }
+
                     if (head && snapshot) {
                         isResolved = true
                         resolve([head, snapshot])
-                    } else {
-                        if (data.type === RecordType.HEAD) {
-                            head = data
-                        } else if (data.type === RecordType.SNAPSHOT) {
-                            snapshot = data
-                        }
+                        this.dispatchEvent('record-data', data as RecordData)
                     }
                 }
             })


### PR DESCRIPTION
This PR stops the TimeCat player hanging after receiving HEAD and SNAPSHOT records until the next record is received.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included