### PR TITLE
feat: locationWatcher is not included in baseWatcher

### DIFF
--- a/packages/recorder/src/recorder.ts
+++ b/packages/recorder/src/recorder.ts
@@ -236,7 +236,8 @@ export class RecorderModule extends Pluginable {
     private async startRecord(options: RecordInternalOptions) {
         let activeWatchers = [...this.watchers, ...this.pluginWatchers]
 
-        if (options.context === this.options.rootContext) {
+        const isSameCtx = options.context === this.options.rootContext
+        if (isSameCtx) {
             if (!options.keep) {
                 this.db.clear()
             }
@@ -291,7 +292,7 @@ export class RecorderModule extends Pluginable {
 
         options.context.G_RECORD_RELATED_ID = relatedId
 
-        if (options.context === this.options.rootContext) {
+        if (isSameCtx) {
             emit({
                 type: RecordType.HEAD,
                 data: headData,
@@ -312,7 +313,7 @@ export class RecorderModule extends Pluginable {
             this.watchersInstance.set(Watcher.name, watcher)
         })
 
-        if (options.emitLocationImmediate) {
+        if (options.emitLocationImmediate && isSameCtx) {
             const locationInstance = this.watchersInstance.get(LocationWatcher.name) as InstanceType<
                 typeof LocationWatcher
             >


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
fix[#93](https://github.com/oct16/TimeCat/issues/93) maybe??

If i didn't miss anything, for iframe watchers (no location watcher included), will cause the `locationInstance?.emitOne()` problem.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
